### PR TITLE
Translatable strings

### DIFF
--- a/resources/js/components/sub-fields/SelectSubField.vue
+++ b/resources/js/components/sub-fields/SelectSubField.vue
@@ -35,7 +35,7 @@
         computed:{
             placeholder(){
                 return (this.subField.placeholder === this.subField.label)
-                    ? 'Choose an option'
+                    ? this.__('Choose an option')
                     : this.subField.placeholder
             }
         }

--- a/resources/js/mixins/RepeaterDisplay.js
+++ b/resources/js/mixins/RepeaterDisplay.js
@@ -12,8 +12,8 @@ export default{
         },
         toggleText() {
             return (this.detailVisible)
-                ? 'Hide detail'
-                : 'Show detail'
+                ? this.__('Hide detail')
+                : this.__('Show detail')
         },
         summaryText() {
             return `${this.summaryTextNumber} ${this.summaryTextLabel}`;


### PR DESCRIPTION
The default SelectSubField placeholder `Choose an option` and hard coded `Hide detail` and `Show detail` string now are translatable via locale file.