### PR TITLE
Remove extra quotes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ If you are displaying your sub fields in a stacked layout then width options wil
         'fido' => 'Fido',
         'mr_bubbles' => 'Mr Bubbles',
         'preston' => 'Preston'
-    ]',
+    ],
     //...
 ]
 ```
@@ -165,7 +165,7 @@ If the `type` of the sub field you are defining is 'select', you will need to de
         'min' => 1,
         'max' => '20',
         'style' => 'color: red'
-    ]',
+    ],
     //...
 ]
 ```


### PR DESCRIPTION
When I was going through the documentation and trying to integrate this code, I noticed that these quotes don't correspond to any others and that the array should just be closed.