### PR TITLE
Add Nova fields method

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -10,6 +10,8 @@
                         :key="index"
                         :index="index"
                         :field="field"
+                        :resource-id="resourceId"
+                        :resource-name="resourceName"
                         @delete-row="deleteRow"
                 ></sub-field-row>
             </draggable>
@@ -94,7 +96,7 @@
 			addNewRow() {
 				if (! this.hasReachedMaximumRows) {
 					let newRow = this.field.sub_fields
-						.map(subField => subField.name)
+						.map(subField => subField.attribute)
 						.reduce((o, key) => ({...o, [key]: null}), {});
 
 					this.rows.push(newRow);

--- a/resources/js/components/rows/SubFieldRow.vue
+++ b/resources/js/components/rows/SubFieldRow.vue
@@ -17,6 +17,7 @@
         </button>
         <div class="row-inputs flex-wrap" :class="formLayout">
             <component
+                v-if="subField.type"
                 v-for="(subField, index) in field.sub_fields"
                 :is="`${subField.type}-sub-field`"
                 :key="index"
@@ -25,6 +26,23 @@
                 class="row-input"
                 :class="getInputLayout(subField)"
             ></component>
+
+            <template
+                v-if="!subField.type"
+                v-for="(subField, i) in field.sub_fields">
+                    <component
+                        :is="'form-' + subField.component"
+                        :key="i"
+                        :name="'f-' + subField.attribute"
+                        :field="subField"
+                        :resource-id="resourceId"
+                        :resource-name="resourceName"
+                        v-model="value[subField.attribute]"
+                        class="row-input"
+                        :class="getInputLayout(subField)"
+                    ></component>
+            </template>
+
         </div>
     </div>
 </template>
@@ -46,7 +64,25 @@
             TextareaSubField,
         },
 
-        props: ['value', 'field', 'index'],
+        props: ['value', 'field', 'index', 'resourceName', 'resourceId'],
+
+        mounted(){
+            var _this = this;
+
+            this.$children.filter(component => {
+                if(component.field){
+                    component.value = _this.value[component.field.attribute]
+                }
+
+                component.$watch(
+                    value => {
+                        if(component.field){
+                            _this.value[component.field.attribute] = component.value
+                        }
+                    }
+                );
+            });
+        },
 
         computed:{
             formLayout(){

--- a/src/Repeater.php
+++ b/src/Repeater.php
@@ -29,6 +29,13 @@ class Repeater extends Field
         ]);
     }
 
+    public function addNovaFields($fieldsConfig)
+    {
+        return $this->withMeta([
+            'sub_fields' => $fieldsConfig,
+        ]);
+    }
+    
     public function addButtonText($text)
     {
         return $this->withMeta([


### PR DESCRIPTION
As discussed here https://github.com/fourstacks/nova-repeatable-fields/issues/34
this is a new branch trying to implement novaFields directly instead of the custom shipped fields. Not ready yet though, working on progress. 

To add Nova fields you can now do something similar to : 
```php
   Repeater::make('Repater','content')
         ->addNovaFields([
             Heading::make('Nova Fields'),
             text::make('question'),
             Textarea::make('answer'),
             Select::make('Size')->options([
                'S' => 'Small',
                'M' => 'Medium',
                'L' => 'Large',
            ]),
            Date::make('Birthday'),
            Country::make('Country')->hideFromIndex(),
         ])
         ->addField([
             'label' => 'Language',
             'name' => 'language',
             'placeholder' => 'Language',
             'type' => 'select',
             'options' => [
                 'ar' => 'Arabic',
                 'en' => 'English',
                 'fr' => 'French',
             ],
         ])
         ->initialRows(1)
         ->displayStackedForm(),
```